### PR TITLE
refactor: Use io.Writer, really buffered cmd exec and use interface for `go list`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ __pycache__/
 
 # For Goenv
 .go-version
+build
+vendor

--- a/gomanifest/build.go
+++ b/gomanifest/build.go
@@ -20,40 +20,52 @@ func main() {
 	// Validate required number of parameters.
 	if len(os.Args) != 3 {
 		log.Error().Msg("invalid arguments for the command")
-		log.Info().Msg("Usage :: go run github.com/fabric8-analytics/cli-tools/gomanifest <Path to source folder> <Output file path>/golist.json")
-		log.Info().Msg("Example :: go run github.com/fabric8-analytics/cli-tools/gomanifest /home/user/goproject/root/folder /home/user/gomanifest.json")
-		os.Exit(-1)
+		log.Info().Msgf("Usage :: %s <Path to source folder> <Output file path>/golist.json", os.Args[0])
+		log.Info().Msgf("Example :: %s /home/user/goproject/root/folder /home/user/gomanifest.json", os.Args[0])
+		os.Exit(1)
 	}
 
 	// Ensure source path exists.
 	_, err := os.Stat(os.Args[1])
 	if err != nil {
-		log.Error().Msgf("Invalid source folder path: %s", os.Args[1])
-		os.Exit(-2)
+		log.Error().Err(err).Msg("invalid")
+		os.Exit(2)
 	}
 
 	// Start generating manifest data.
 	log.Info().Msgf("Started analysing go project at %s", os.Args[1])
-	goList := &internal.GoList{Command: &internal.GoListCmd{CWD: os.Args[1]}}
-	depPackages, err := goList.Get()
+	cmd, err := internal.RunGoList(os.Args[1])
 	if err != nil {
-		log.Error().Msgf("Exception raised: %v", err)
-		os.Exit(-3)
+		log.Error().Err(err).Msg("`go list` failed")
+		os.Exit(3)
+	}
+
+	depPackages, err := internal.GetDeps(cmd)
+	if err != nil {
+		log.Error().Err(err).Msg("get deps")
+		os.Exit(3)
 	}
 
 	manifest := internal.BuildManifest(&depPackages)
 	// Check for empty manifest file.
 	if manifest.Main == "" {
 		log.Error().Msg("Empty manifest generated, correct project dependencies using `go mod tidy` command")
-		os.Exit(-4)
+		os.Exit(4)
 	}
 
-	err = manifest.Save(os.Args[2])
+	// Create out file.
+	f, err := os.Create(os.Args[2])
 	if err != nil {
-		log.Error().Msgf("Exception raised: %v", err)
-		os.Exit(-5)
+		log.Error().Err(err).Msg("unable to write")
+		os.Exit(4)
+	}
+	defer f.Close()
+
+	err = manifest.Write(f)
+	if err != nil {
+		log.Error().Err(err).Msg("unable to write")
+		os.Exit(5)
 	}
 
 	log.Info().Msgf("Manifest file generated and stored at %s", os.Args[2])
-	os.Exit(0)
 }

--- a/gomanifest/internal/deps.go
+++ b/gomanifest/internal/deps.go
@@ -2,8 +2,9 @@ package internal
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
-	"os/exec"
 
 	"github.com/rs/zerolog/log"
 )
@@ -28,33 +29,17 @@ type DepPackage struct {
 	Deps       []string  `json:"Deps"`
 }
 
-// GoListCmd ... Go list command structure.
-type GoListCmd struct {
-	CWD string
-}
-
-// Run ... Actual function that executes go list command and returns output as string.
-func (goListCmd GoListCmd) Run() (io.ReadCloser, error) {
-	GoListGoListDeps := exec.Command("go", "list", "-json", "-deps", "./...")
-	GoListGoListDeps.Dir = goListCmd.CWD
-	defer GoListGoListDeps.Start()
-	GoListGoListDeps.Wait()
-	return GoListGoListDeps.StdoutPipe()
-}
-
 // GoListCmdInterface ... Interface to be implemented to execute go list command.
-type GoListCmdInterface interface {
-	Run() (io.ReadCloser, error)
-}
-
-// GoList ... Structure that handle go list data and extract required packages.
-type GoList struct {
-	Command GoListCmdInterface
+type GoList interface {
+	ReadCloser() io.ReadCloser
+	Wait() error
 }
 
 // parseDepsJSON ... Parse json output of go list -dep command.
-func parseDepsJSON(out chan<- DepPackage, in io.Reader) {
-	defer close(out)
+func parseDepsJSON(dataC chan<- DepPackage, errorC chan<- error, in io.ReadCloser) {
+	defer close(dataC)
+	defer close(errorC)
+	defer in.Close()
 
 	dec := json.NewDecoder(in)
 	for {
@@ -62,34 +47,36 @@ func parseDepsJSON(out chan<- DepPackage, in io.Reader) {
 		if err := dec.Decode(&m); err == io.EOF {
 			break
 		} else if err != nil {
-			log.Error().Msg("Parsing json data failed.")
-			panic(err)
+			errorC <- err
+			break
 		}
-		out <- m
+		dataC <- m
 	}
 }
 
-// Get ... Get deps data through go list deps command and converts json into objects.
-func (goList *GoList) Get() (map[string]DepPackage, error) {
+// GetDeps ... GetDeps converts GoList output into DepPackage format.
+func GetDeps(cmd GoList) (map[string]DepPackage, error) {
 	var depPackagesMap = make(map[string]DepPackage)
 
-	output, err := goList.Command.Run()
-	if err != nil {
-		log.Error().Msgf("`go list` command failed, clean dependencies using `go mod tidy` command")
-		return nil, err
-	}
+	dataC := make(chan DepPackage, 0)
+	errorC := make(chan error, 1)
+	go parseDepsJSON(dataC, errorC, cmd.ReadCloser())
 
-	ch := make(chan DepPackage, 0)
-	go parseDepsJSON(ch, output)
-
-	// Preprocess and remove all standard packages.
-	for pckg := range ch {
+	for pckg := range dataC {
 		// Exclude standard packages
 		if !pckg.Standard {
 			depPackagesMap[pckg.ImportPath] = pckg
 		}
 	}
-	log.Info().Msgf("Total packages: \t\t%d", len(depPackagesMap))
 
+	// Check for json Decode error.
+	if err := <-errorC; err != nil {
+		return nil, err
+	}
+	// Wait for the `go list` command to complete.
+	if err := cmd.Wait(); err != nil {
+		return nil, errors.New(fmt.Sprintf("%v: `go list` failed, use `go mod tidy` to known more", err))
+	}
+	log.Info().Msgf("Total packages: \t\t%d", len(depPackagesMap))
 	return depPackagesMap, nil
 }

--- a/gomanifest/internal/deps.go
+++ b/gomanifest/internal/deps.go
@@ -29,7 +29,7 @@ type DepPackage struct {
 	Deps       []string  `json:"Deps"`
 }
 
-// GoListCmdInterface ... Interface to be implemented to execute go list command.
+// GoList ... Interface to be implemented to execute go list command.
 type GoList interface {
 	ReadCloser() io.ReadCloser
 	Wait() error

--- a/gomanifest/internal/golist.go
+++ b/gomanifest/internal/golist.go
@@ -1,0 +1,36 @@
+package internal
+
+import (
+	"io"
+	"os/exec"
+)
+
+// GoListCmd ... Go list command structure.
+type GoListCmd struct {
+	cmd    *exec.Cmd
+	output io.ReadCloser
+}
+
+// RunGoList ... Actual function that executes go list command and returns output as string.
+func RunGoList(cwd string) (*GoListCmd, error) {
+	goList := exec.Command("go", "list", "-json", "-deps", "./...")
+	goList.Dir = cwd
+	output, err := goList.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err = goList.Start(); err != nil {
+		return nil, err
+	}
+	return &GoListCmd{cmd: goList, output: output}, nil
+}
+
+// ReadCloser implements internal.GoList
+func (list *GoListCmd) ReadCloser() io.ReadCloser {
+	return list.output
+}
+
+// Wait implements internal.GoList
+func (list *GoListCmd) Wait() error {
+	return list.cmd.Wait()
+}

--- a/gomanifest/internal/manifest.go
+++ b/gomanifest/internal/manifest.go
@@ -2,7 +2,7 @@ package internal
 
 import (
 	"encoding/json"
-	"os"
+	"io"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -26,23 +26,16 @@ type Manifest struct {
 }
 
 // Save ... Save manifest object into a given save path.
-func (manifest Manifest) Save(savePath string) error {
+func (manifest Manifest) Write(writer io.Writer) error {
 	d, err := json.Marshal(manifest)
 	if err != nil {
 		return err
 	}
 
-	f, err := os.Create(savePath)
+	_, err = writer.Write(d)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-
-	_, err = f.Write(d)
-	if err != nil {
-		return err
-	}
-	f.Sync()
 
 	return nil
 }

--- a/gomanifest/internal/manifest_test.go
+++ b/gomanifest/internal/manifest_test.go
@@ -1,7 +1,8 @@
 package internal
 
 import (
-	"os"
+	"bytes"
+	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -143,14 +144,13 @@ func TestBuildManifest(t *testing.T) {
 }
 
 func TestSaveManifest(t *testing.T) {
-	manifestFilePath := testDataFolder + testOutputManifest
-
-	defer os.Remove(manifestFilePath)
-
+	var b bytes.Buffer
 	manifest := BuildManifest(&testDepPackagesMap)
-	manifest.Save(manifestFilePath)
+	err := manifest.Write(&b)
+	assert.Equal(t, nil, err)
+	manifestContent, err := ioutil.ReadAll(&b)
+	assert.Equal(t, nil, err)
 
 	// Read output json and check for its size
-	output := readFileContentForTesting(testOutputManifest)
-	assert.Equal(t, 144, len(output), "Output manifest file size missmatch")
+	assert.Equal(t, 144, len(manifestContent), "Output manifest file size missmatch")
 }


### PR DESCRIPTION
- Use io.Writer to write Manifest
- Use generic interface to execute `go list`. It expose io.ReadCloser for efficient stdout streaming and Wait for the command execution to complete.
- Use error channel to fetch error from concurrent JSON streaming decoder