### PR TITLE
fix: [APPAI-1643] Avoid changes in go.mod during manifest file generation

### DIFF
--- a/gomanifest/internal/golist.go
+++ b/gomanifest/internal/golist.go
@@ -13,7 +13,7 @@ type GoListCmd struct {
 
 // RunGoList ... Actual function that executes go list command and returns output as string.
 func RunGoList(cwd string) (*GoListCmd, error) {
-	goList := exec.Command("go", "list", "-json", "-deps", "./...")
+	goList := exec.Command("go", "list", "-json", "-deps", "-mod=readonly", "./...")
 	goList.Dir = cwd
 	output, err := goList.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
Building manifest file for go stack might update go.mod. Need to add -mod=readonly flag to avoid any update of existing go.mod file.

Jira ticket :: https://issues.redhat.com/browse/APPAI-1643