### PR TITLE
feat: [APPAI-1650] Take go executable path in the command

### DIFF
--- a/gomanifest/build.go
+++ b/gomanifest/build.go
@@ -14,10 +14,10 @@ func main() {
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 
 	// Validate required number of parameters.
-	if len(os.Args) != 3 {
+	if len(os.Args) != 3 && len(os.Args) != 4 {
 		log.Error().Msg("invalid arguments for the command")
-		log.Info().Msgf("Usage :: %s <Path to source folder> <Output file path>/golist.json", os.Args[0])
-		log.Info().Msgf("Example :: %s /home/user/goproject/root/folder /home/user/gomanifest.json", os.Args[0])
+		log.Info().Msgf("Usage :: go run github.com/fabric8-analytics/cli-tools/gomanifest <Path to source folder> <Output file path>/golist.json [<Go executable path>]")
+		log.Info().Msgf("Example :: go run github.com/fabric8-analytics/cli-tools/gomanifest /home/user/goproject/root/folder /home/user/golist.json /usr/local/bin/go")
 		os.Exit(1)
 	}
 
@@ -28,9 +28,15 @@ func main() {
 		os.Exit(2)
 	}
 
+	// Extract go executable path, if given
+	goExec := "go"
+	if len(os.Args) == 4 {
+		goExec = os.Args[3]
+	}
+
 	// Start generating manifest data.
-	log.Info().Msgf("Started analysing go project at %s", os.Args[1])
-	cmd, err := internal.RunGoList(os.Args[1])
+	log.Info().Msgf("Started analysing go project at [%s] using go exec [%s]", os.Args[1], goExec)
+	cmd, err := internal.RunGoList(os.Args[1], goExec)
 	if err != nil {
 		log.Error().Err(err).Msg("`go list` failed")
 		os.Exit(3)

--- a/gomanifest/build.go
+++ b/gomanifest/build.go
@@ -14,7 +14,8 @@ func main() {
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 
 	// Validate required number of parameters.
-	if len(os.Args) != 3 && len(os.Args) != 4 {
+	argsLen := len(os.Args)
+	if argsLen != 3 && argsLen != 4 {
 		log.Error().Msg("invalid arguments for the command")
 		log.Info().Msgf("Usage :: go run github.com/fabric8-analytics/cli-tools/gomanifest <Path to source folder> <Output file path>/golist.json [<Go executable path>]")
 		log.Info().Msgf("Example :: go run github.com/fabric8-analytics/cli-tools/gomanifest /home/user/goproject/root/folder /home/user/golist.json /usr/local/bin/go")
@@ -30,7 +31,7 @@ func main() {
 
 	// Extract go executable path, if given
 	goExec := "go"
-	if len(os.Args) == 4 {
+	if argsLen == 4 {
 		goExec = os.Args[3]
 	}
 

--- a/gomanifest/build.go
+++ b/gomanifest/build.go
@@ -25,19 +25,24 @@ func main() {
 	// Ensure source path exists.
 	_, err := os.Stat(os.Args[1])
 	if err != nil {
-		log.Error().Err(err).Msg("invalid")
+		log.Error().Err(err).Msg("invalid folder")
 		os.Exit(2)
 	}
 
 	// Extract go executable path, if given
 	goExec := "go"
 	if argsLen == 4 {
+		_, err := os.Stat(os.Args[3])
+		if err != nil {
+			log.Error().Err(err).Msg("invalid executable")
+			os.Exit(3)
+		}
 		goExec = os.Args[3]
 	}
 
 	// Start generating manifest data.
 	log.Info().Msgf("Started analysing go project at [%s] using go exec [%s]", os.Args[1], goExec)
-	cmd, err := internal.RunGoList(os.Args[1], goExec)
+	cmd, err := internal.RunGoList(goExec, os.Args[1])
 	if err != nil {
 		log.Error().Err(err).Msg("`go list` failed")
 		os.Exit(3)
@@ -46,7 +51,7 @@ func main() {
 	depPackages, err := internal.GetDeps(cmd)
 	if err != nil {
 		log.Error().Err(err).Msg("get deps")
-		os.Exit(3)
+		os.Exit(4)
 	}
 
 	manifest := internal.BuildManifest(&depPackages)
@@ -59,15 +64,15 @@ func main() {
 	// Create out file.
 	f, err := os.Create(os.Args[2])
 	if err != nil {
-		log.Error().Err(err).Msg("unable to write")
-		os.Exit(4)
+		log.Error().Err(err).Msg("unable to create")
+		os.Exit(5)
 	}
 	defer f.Close()
 
 	err = manifest.Write(f)
 	if err != nil {
 		log.Error().Err(err).Msg("unable to write")
-		os.Exit(5)
+		os.Exit(6)
 	}
 
 	log.Info().Msgf("Manifest file generated and stored at %s", os.Args[2])

--- a/gomanifest/internal/golist.go
+++ b/gomanifest/internal/golist.go
@@ -12,8 +12,8 @@ type GoListCmd struct {
 }
 
 // RunGoList ... Actual function that executes go list command and returns output as string.
-func RunGoList(cwd string) (*GoListCmd, error) {
-	goList := exec.Command("go", "list", "-json", "-deps", "-mod=readonly", "./...")
+func RunGoList(cwd string, goExec string) (*GoListCmd, error) {
+	goList := exec.Command(goExec, "list", "-json", "-deps", "-mod=readonly", "./...")
 	goList.Dir = cwd
 	output, err := goList.StdoutPipe()
 	if err != nil {

--- a/gomanifest/internal/golist.go
+++ b/gomanifest/internal/golist.go
@@ -12,7 +12,7 @@ type GoListCmd struct {
 }
 
 // RunGoList ... Actual function that executes go list command and returns output as string.
-func RunGoList(cwd string, goExec string) (*GoListCmd, error) {
+func RunGoList(goExec string, cwd string) (*GoListCmd, error) {
 	goList := exec.Command(goExec, "list", "-json", "-deps", "-mod=readonly", "./...")
 	goList.Dir = cwd
 	output, err := goList.StdoutPipe()


### PR DESCRIPTION
Go manifest package uses 'go' to generate deps data required for manifest file. Caller sometime does not have 'go' executable set in its path and hence package could not locate this executable. This change will allow user to pass absolute go executable path as an argument and same will be used by this package. If this argument is not provided script shall use 'go' as executable name.

Jira Ticket :: https://issues.redhat.com/browse/APPAI-1650