### PR TITLE
chore: crda cli GH Actions Release Job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2 
+    - uses: actions/checkout@v2
     - name: Set up Go
       uses: actions/setup-go@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-
+    - uses: actions/checkout@v2 
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
@@ -18,12 +17,6 @@ jobs:
     - name: Generate CLI Build
       run: |
           go build -o dist/crda
-    - name: Archive production artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: crda
-        path: |
-          dist
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15
+    - name: Generate CLI Build
+      run: |
+          go build -o dist/crda
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: crda
+        path: |
+          dist
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v2
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        version: latest
+        args: release --rm-dist
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,6 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.15
-    - name: Generate CLI Build
-      run: |
-          go build -o dist/crda
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       if: startsWith(github.ref, 'refs/tags/')

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,34 @@
+project_name: crda
+archives:
+  - files:
+      - LICENSE
+      - docs/cli_README.md
+builds:
+  - env: [CGO_ENABLED=0]
+    main: ./main.go
+    id: "cli"
+    binary: crda
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: 386
+      - goos: linux
+        goarch: arm
+        goarm: 7
+      - goarm: mips64
+        gomips: hardfloat
+nfpms:
+- maintainer: Deepak Sharma <deepshar@redhat.com>
+  description: CLI Tools for CRDA.
+  homepage: https://github.com/fabric8-analytics/cli-tools
+  license: MIT
+  formats:
+  - deb
+  - rpm
+  - apk


### PR DESCRIPTION
CRDA CLI GH Actions Release Job

To create a Release:
- Create a Tag in format `vx.x.x` (Ex: v0.0.1), where it is a version no. in Semantic Format
- This will trigger a Build Job, Latest Release can be found in [Releases](https://github.com/fabric8-analytics/cli-tools/releases/)
- Edit `release` to add Metadata, if required.

We are using GoReleaser Github Actions. [Learn more](https://goreleaser.com/ci/actions/)


Example Release:
https://github.com/deepak1725/cli-tools/releases/tag/v0.0.1