### PR TITLE
fix: github actions release job fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       if: startsWith(github.ref, 'refs/tags/')

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: 386
+      - goos: darwin
+        goarch: arm64
       - goos: linux
         goarch: arm
         goarm: 7


### PR DESCRIPTION
Release Job is failing due to latest release in Go Releaser https://github.com/goreleaser/goreleaser/releases/tag/v0.156.2

This fix accommodates changes required by the latest "go releaser" for existing build jobs.