### PR TITLE
feat: added cli version command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,7 @@ builds:
     main: ./main.go
     ldflags: 
       - -s -w -X github.com/fabric8-analytics/cli-tools/cmd.Version={{.Version}} 
-      - -X github.com/fabric8-analytics/cli-tools/cmd.VendorInfo=CRDA
+      - '-X github.com/fabric8-analytics/cli-tools/cmd.VendorInfo="Red Hat"'
       - -X github.com/fabric8-analytics/cli-tools/cmd.Timestamp={{ .Timestamp }} 
       - -X github.com/fabric8-analytics/cli-tools/cmd.CommitHash={{ .ShortCommit }}
     id: crda

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,7 @@ builds:
       - -X github.com/fabric8-analytics/cli-tools/cmd.VendorInfo=CRDA
       - -X github.com/fabric8-analytics/cli-tools/cmd.Timestamp={{ .Timestamp }} 
       - -X github.com/fabric8-analytics/cli-tools/cmd.CommitHash={{ .ShortCommit }}
-    id: "crda"
+    id: crda
     binary: crda
     goos:
       - linux
@@ -42,10 +42,10 @@ builds:
       - goarm: mips64
         gomips: hardfloat 
 nfpms:
-- id: "crda"
-  vendor: "CRDA"
+- id: crda
+  vendor: CRDA
   maintainer: Deepak Sharma <deepshar@redhat.com>
-  description: CLI Tools for CRDA.
+  description: CLI Tools from team CRDA.
   homepage: https://github.com/fabric8-analytics/cli-tools
   license: MIT
   file_name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}-{{.Arch}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,10 +3,31 @@ archives:
   - files:
       - LICENSE
       - docs/cli_README.md
+    replacements:
+      amd64: 64bit
+      arm64: ARM64
+      darwin: macOS
+      linux: Linux
+      windows: Windows
+release:
+  draft: true
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - typo
+      - (?i)foo
 builds:
-  - env: [CGO_ENABLED=0]
+  - env: 
+    - CGO_ENABLED=0 
     main: ./main.go
-    id: "cli"
+    ldflags: 
+      - -s -w -X github.com/fabric8-analytics/cli-tools/cmd.Version={{.Version}} 
+      - -X github.com/fabric8-analytics/cli-tools/cmd.VendorInfo=CRDA
+      - -X github.com/fabric8-analytics/cli-tools/cmd.Timestamp={{ .Timestamp }} 
+      - -X github.com/fabric8-analytics/cli-tools/cmd.CommitHash={{ .ShortCommit }}
+    id: "crda"
     binary: crda
     goos:
       - linux
@@ -16,21 +37,24 @@ builds:
       - amd64
       - arm64
     ignore:
-      - goos: darwin
-        goarch: 386
-      - goos: darwin
-        goarch: arm64
       - goos: linux
-        goarch: arm
-        goarm: 7
+        goarch: arm64
       - goarm: mips64
-        gomips: hardfloat
+        gomips: hardfloat 
 nfpms:
-- maintainer: Deepak Sharma <deepshar@redhat.com>
+- id: "crda"
+  vendor: "CRDA"
+  maintainer: Deepak Sharma <deepshar@redhat.com>
   description: CLI Tools for CRDA.
   homepage: https://github.com/fabric8-analytics/cli-tools
   license: MIT
+  file_name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}-{{.Arch}}"
+  replacements:
+      amd64: 64bit
+      arm64: ARM64
+      darwin: macOS
+      linux: Linux
+      windows: Windows
   formats:
   - deb
   - rpm
-  - apk

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,7 @@ builds:
     main: ./main.go
     ldflags: 
       - -s -w -X github.com/fabric8-analytics/cli-tools/cmd.Version={{.Version}} 
-      - '-X github.com/fabric8-analytics/cli-tools/cmd.VendorInfo="Red Hat"'
+      - "-X 'github.com/fabric8-analytics/cli-tools/cmd.VendorInfo=Red Hat'"
       - -X github.com/fabric8-analytics/cli-tools/cmd.Timestamp={{ .Timestamp }} 
       - -X github.com/fabric8-analytics/cli-tools/cmd.CommitHash={{ .ShortCommit }}
     id: crda

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ REPO=github.com/fabric8-analytics/cli-tools
 VERSION?=0.0.1
 EXPORT_RESULT?=false
 CGO_ENABLED:=0
-LDFLAGS:=-X ${REPO}/cmd.VendorInfo=LocalBuild
 LDFLAGS +=-X ${REPO}/cmd.Timestamp=$(shell date +%s)
 LDFLAGS +=-X ${REPO}/cmd.Version=${VERSION}
 LDFLAGS +=-X ${REPO}/cmd.CommitHash=${GITCOMMIT}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,82 @@
+GOCMD=go
+GOTEST=$(GOCMD) test
+GOVET=$(GOCMD) vet
+BINARY_NAME=crda
+GITCOMMIT:=$(shell git rev-parse --short HEAD)
+REPO=github.com/fabric8-analytics/cli-tools
+VERSION?=0.0.1
+EXPORT_RESULT?=false
+CGO_ENABLED:=0
+LDFLAGS:=-X ${REPO}/cmd.VendorInfo=LocalBuild
+LDFLAGS +=-X ${REPO}/cmd.Timestamp=$(shell date +%s)
+LDFLAGS +=-X ${REPO}/cmd.Version=${VERSION}
+LDFLAGS +=-X ${REPO}/cmd.CommitHash=${GITCOMMIT}
+
+GREEN  := $(shell tput -Txterm setaf 2)
+YELLOW := $(shell tput -Txterm setaf 3)
+WHITE  := $(shell tput -Txterm setaf 7)
+RESET  := $(shell tput -Txterm sgr0)
+
+.PHONY: all test build vendor
+
+all: help
+
+lint: lint-go lint-yaml
+
+
+lint-go:
+	$(eval OUTPUT_OPTIONS = $(shell [ "${EXPORT_RESULT}" == "true" ] && echo "--out-format checkstyle ./... | tee /dev/tty > checkstyle-report.xml" || echo "" ))
+	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:latest-alpine golangci-lint run --deadline=65s $(OUTPUT_OPTIONS)
+
+lint-yaml:
+ifeq ($(EXPORT_RESULT), true)
+	GO111MODULE=off go get -u github.com/thomaspoignant/yamllint-checkstyle
+	$(eval OUTPUT_OPTIONS = | tee /dev/tty | yamllint-checkstyle > yamllint-checkstyle.xml)
+endif
+	docker run --rm -it -v $(shell pwd):/data cytopia/yamllint -f parsable $(shell git ls-files '*.yml' '*.yaml') $(OUTPUT_OPTIONS)
+
+clean:
+	rm -fr $(which crda)
+	rm -fr ./out
+	rm -f ./junit-report.xml checkstyle-report.xml ./coverage.xml ./profile.cov yamllint-checkstyle.xml
+
+test:
+ifeq ($(EXPORT_RESULT), true)
+	GO111MODULE=off go get -u github.com/jstemmer/go-junit-report
+	$(eval OUTPUT_OPTIONS = | tee /dev/tty | go-junit-report -set-exit-code > junit-report.xml)
+endif
+	$(GOTEST) -v -race ./... $(OUTPUT_OPTIONS)
+
+coverage:
+	$(GOTEST) -cover -covermode=count -coverprofile=profile.cov ./...
+	$(GOCMD) tool cover -func profile.cov
+ifeq ($(EXPORT_RESULT), true)
+	GO111MODULE=off go get -u github.com/AlekSi/gocov-xml
+	GO111MODULE=off go get -u github.com/axw/gocov/gocov
+	gocov convert profile.cov | gocov-xml > coverage.xml
+endif
+
+vendor:
+	$(GOCMD) mod vendor
+
+build:
+	mkdir -p /usr/local/bin
+	CGO_ENABLED=$(CGO_ENABLED) $(GOCMD) build -v \
+	-ldflags="-s -w $(LDFLAGS)" \
+	-o $(BINARY_NAME)
+
+help:
+	@echo ''
+	@echo 'Usage:'
+	@echo '  ${YELLOW}make${RESET} ${GREEN}<target>${RESET}'
+	@echo ''
+	@echo 'Targets:'
+	@echo "  ${YELLOW}build           ${RESET} ${GREEN}Build your project and put the output binary in /usr/local/bin/$(BINARY_NAME)${RESET}"
+	@echo "  ${YELLOW}clean           ${RESET} ${GREEN}Remove build related file${RESET}"
+	@echo "  ${YELLOW}coverage        ${RESET} ${GREEN}Run the tests of the project and export the coverage${RESET}"
+	@echo "  ${YELLOW}help            ${RESET} ${GREEN}Show this help message${RESET}"
+	@echo "  ${YELLOW}lint            ${RESET} ${GREEN}Run all available linters${RESET}"
+	@echo "  ${YELLOW}lint-go         ${RESET} ${GREEN}Use golintci-lint on your project${RESET}"
+	@echo "  ${YELLOW}lint-yaml       ${RESET} ${GREEN}Use yamllint on the yaml file of your projects${RESET}"
+	@echo "  ${YELLOW}test            ${RESET} ${GREEN}Run the tests of the project${RESET}"
+	@echo "  ${YELLOW}vendor          ${RESET} ${GREEN}Copy of all packages needed to support builds and tests in the vendor directory${RESET}"

--- a/README.md
+++ b/README.md
@@ -22,45 +22,7 @@ This repo would server as an interface between the different CRDA clients and th
 To make changes in this tool you need to install `go` and development environment for executing go commands. Get the source from the repository.
 
 #### Test
-This tool has unit test which are packged along with source code. Required test data can be stored under `testdata` folder. Unit tests can be executes be using below command:
-
-```
-
-go test -v -cover ./...
-
-```
-
+This tool has unit test which are packged along with source code. Required test data can be stored under `testdata` folder. 
 Execute above command at root of the source tree, it runs all test cases and provides oneliner output in code coverage.
-Sample output is as below:
 
-```
-$ go test -cover -v ./...
-=== RUN   TestMainWithInvalidNumOfArgs
---- PASS: TestMainWithInvalidNumOfArgs (0.13s)
-=== RUN   TestMainWithInvalidFolder
---- PASS: TestMainWithInvalidFolder (0.13s)
-=== RUN   TestMainHappyCase
---- PASS: TestMainHappyCase (0.14s)
-PASS
-coverage: 0.0% of statements
-ok  	github.com/fabric8-analytics/cli-tools/gomanifest	(cached)	coverage: 0.0% of statements
-=== RUN   TestProcessDepsDataFailCase
-{"level":"error","time":"2020-11-05T14:07:35+05:30","message":"`go list` command failed, clean dependencies using `go mod tidy` command"}
---- PASS: TestProcessDepsDataFailCase (0.00s)
-=== RUN   TestProcessDepsDataHappyCase
-{"level":"info","time":"2020-11-05T14:07:35+05:30","message":"Total packages: \t\t12"}
---- PASS: TestProcessDepsDataHappyCase (0.00s)
-=== RUN   TestTransformationVerionSemVer
---- PASS: TestTransformationVerionSemVer (0.00s)
-=== RUN   TestBuildManifest
-{"level":"info","time":"2020-11-05T14:07:35+05:30","message":"Source code imports: \t13"}
-{"level":"info","time":"2020-11-05T14:07:35+05:30","message":"Direct dependencies: \t1"}
---- PASS: TestBuildManifest (0.00s)
-=== RUN   TestSaveManifest
-{"level":"info","time":"2020-11-05T14:07:35+05:30","message":"Source code imports: \t13"}
-{"level":"info","time":"2020-11-05T14:07:35+05:30","message":"Direct dependencies: \t1"}
---- PASS: TestSaveManifest (0.00s)
-PASS
-coverage: 79.4% of statements
-ok  	github.com/fabric8-analytics/cli-tools/gomanifest/internal	(cached)	coverage: 79.4% of statements
-```
+`make test`

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -23,7 +23,7 @@ var (
 	// commitHash contains the current Git revision.
 	CommitHash string = "abcd"
 	// Timestamp contains the UnixTimestamp of the binary build.
-	Timestamp string = "1615361906"
+	Timestamp string = "0"
 	// VendorInfo contains vendor notes about the current build.
 	VendorInfo string = "Local Build"
 )

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -23,7 +23,7 @@ var (
 	// commitHash contains the current Git revision.
 	CommitHash string
 	// Timestamp contains the UnixTimestamp of the binary build.
-	Timestamp string = "1405544146"
+	Timestamp string
 	// VendorInfo contains vendor notes about the current build.
 	VendorInfo string
 )

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -47,11 +47,11 @@ func getVersion(cmd *cobra.Command, args []string) {
 		i, err := strconv.ParseInt(Timestamp, 10, 64)
 		if err == nil {
 			tm := time.Unix(i, 0)
-			versionString += " BuildDate: " + tm.Format(time.RFC1123)
+			versionString += " BuildDate:" + tm.Format(time.RFC1123)
 		}
 	}
 	if VendorInfo != "" {
-		versionString += fmt.Sprintf(" Vendor: %s", VendorInfo)
+		versionString += fmt.Sprintf("  Vendor:%s", VendorInfo)
 	}
 
 	fmt.Println(versionString)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -51,7 +51,7 @@ func getVersion(cmd *cobra.Command, args []string) {
 		}
 	}
 	if VendorInfo != "" {
-		versionString += fmt.Sprintf("Vendor: %s", VendorInfo)
+		versionString += fmt.Sprintf(" Vendor: %s", VendorInfo)
 	}
 
 	fmt.Println(versionString)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"fmt"
+	"runtime"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Get binary version.",
+	Long:  `Command to output version of a binary.`,
+	Run:   getVersion,
+}
+
+// Version string populated by releaser Job
+var (
+	Version string = "0.0.0"
+	// commitHash contains the current Git revision.
+	CommitHash string
+	// Timestamp contains the UnixTimestamp of the binary build.
+	Timestamp string = "1405544146"
+	// VendorInfo contains vendor notes about the current build.
+	VendorInfo string
+)
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
+
+func getVersion(cmd *cobra.Command, args []string) {
+
+	version := "v" + Version
+	if CommitHash != "" {
+		version += "-" + CommitHash
+	}
+	osArch := runtime.GOOS + "/" + runtime.GOARCH
+
+	versionString := fmt.Sprintf("%s %s ",
+		version, osArch)
+
+	if Timestamp != "" {
+		i, err := strconv.ParseInt(Timestamp, 10, 64)
+		if err == nil {
+			tm := time.Unix(i, 0)
+			versionString += " BuildDate: " + tm.Format(time.RFC1123)
+		}
+	}
+	if VendorInfo != "" {
+		versionString += fmt.Sprintf("Vendor: %s", VendorInfo)
+	}
+
+	fmt.Println(versionString)
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -21,11 +21,11 @@ var versionCmd = &cobra.Command{
 var (
 	Version string = "0.0.0"
 	// commitHash contains the current Git revision.
-	CommitHash string
+	CommitHash string = "abcd"
 	// Timestamp contains the UnixTimestamp of the binary build.
-	Timestamp string
+	Timestamp string = "1615361906"
 	// VendorInfo contains vendor notes about the current build.
-	VendorInfo string
+	VendorInfo string = "Local Build"
 )
 
 func init() {
@@ -47,11 +47,11 @@ func getVersion(cmd *cobra.Command, args []string) {
 		i, err := strconv.ParseInt(Timestamp, 10, 64)
 		if err == nil {
 			tm := time.Unix(i, 0)
-			versionString += " BuildDate:" + tm.Format(time.RFC1123)
+			versionString += fmt.Sprintf(" BuildDate: %s", tm.Format(time.RFC1123))
 		}
 	}
 	if VendorInfo != "" {
-		versionString += fmt.Sprintf("  Vendor:%s", VendorInfo)
+		versionString += fmt.Sprintf("  Vendor: %s", VendorInfo)
 	}
 
 	fmt.Println(versionString)


### PR DESCRIPTION
This PR adds the `version` command in the CLI tool

Update Release Job to populate Build time variables via Ldflags 

Example Release: https://github.com/deepak1725/cli-tools/releases/tag/v0.0.7