### PR TITLE
fix: golang-ci linter to work on all dirs

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -27,7 +27,6 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with: 
           version: v1.29
-          working-directory: gomanifest
           skip-build-cache: true
           skip-pkg-cache: true
   golint:


### PR DESCRIPTION
#description 

make golang ci lint to work on all repos