### PR TITLE
chore: remove deprecated ioutil package

### DIFF
--- a/gomanifest/generator/deps_test.go
+++ b/gomanifest/generator/deps_test.go
@@ -3,7 +3,7 @@ package generator
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -15,7 +15,7 @@ import (
 const testDataFolder = "./../../testdata/"
 
 func readFileContentForTesting(fileName string) string {
-	content, err := ioutil.ReadFile(testDataFolder + fileName)
+	content, err := os.ReadFile(testDataFolder + fileName)
 	if err != nil {
 		log.Fatal().Msgf("Exception: %v", err)
 	}
@@ -32,7 +32,7 @@ type FakeGoListCmd struct {
 // ReadCloser implements internal.GoList
 func (mock *FakeGoListCmd) ReadCloser() io.ReadCloser {
 	args := mock.Called()
-	return ioutil.NopCloser(strings.NewReader(args.String(0)))
+	return io.NopCloser(strings.NewReader(args.String(0)))
 }
 
 // Wait implements internal.GoList

--- a/gomanifest/generator/manifest_test.go
+++ b/gomanifest/generator/manifest_test.go
@@ -2,7 +2,7 @@ package generator
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -161,7 +161,7 @@ func TestSaveManifest(t *testing.T) {
 	manifest := BuildManifest(&testDepPackagesMap)
 	err := manifest.Write(&b)
 	assert.Equal(t, nil, err)
-	manifestContent, err := ioutil.ReadAll(&b)
+	manifestContent, err := io.ReadAll(&b)
 	assert.Equal(t, nil, err)
 
 	// Read output json and check for its size

--- a/pkg/analyses/golang/matcher.go
+++ b/pkg/analyses/golang/matcher.go
@@ -3,7 +3,6 @@ package golang
 import (
 	"errors"
 	"github.com/fabric8-analytics/cli-tools/pkg/utils"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -33,7 +32,7 @@ func (m *Matcher) IgnoreVulnerabilities(manifestPath string) (map[string][]strin
 	//Ignore Vulnerabilities to be implemented for golang manifests
 	log.Debug().Msgf("Extracting Packages and Vulnerabilities to Ignore.")
 	ignoreVulnerabilities := make(map[string][]string)
-	manifestFile, err := ioutil.ReadFile(manifestPath)
+	manifestFile, err := os.ReadFile(manifestPath)
 
 	if err != nil {
 		return ignoreVulnerabilities, err

--- a/pkg/analyses/maven/matcher.go
+++ b/pkg/analyses/maven/matcher.go
@@ -6,7 +6,6 @@ import (
 	"github.com/fabric8-analytics/cli-tools/pkg/analyses/driver"
 	"github.com/fabric8-analytics/cli-tools/pkg/utils"
 	"github.com/rs/zerolog/log"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -59,7 +58,7 @@ func (m *Matcher) GeneratorDependencyTree(manifestFilePath string) string {
 func (m *Matcher) IgnoreVulnerabilities(manifestPath string) (map[string][]string, error) {
 	log.Debug().Msgf("Extracting Packages and Vulnerabilities to Ignore.")
 	ignoreVulnerabilities := make(map[string][]string)
-	manifestFile, err := ioutil.ReadFile(manifestPath)
+	manifestFile, err := os.ReadFile(manifestPath)
 
 	if err != nil {
 		return ignoreVulnerabilities, err

--- a/pkg/analyses/npm/matcher.go
+++ b/pkg/analyses/npm/matcher.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -65,7 +64,7 @@ func (m *Matcher) GeneratorDependencyTree(manifestFilePath string) string {
 func (m *Matcher) IgnoreVulnerabilities(manifestPath string) (map[string][]string, error) {
 	//Ignore Vulnerabilities for npm manifests
 	log.Debug().Msgf("Extracting Packages and Vulnerabilities to Ignore.")
-	manifestFile, err := ioutil.ReadFile(manifestPath)
+	manifestFile, err := os.ReadFile(manifestPath)
 
 	if err != nil {
 		return nil, err

--- a/pkg/analyses/pypi/matcher.go
+++ b/pkg/analyses/pypi/matcher.go
@@ -7,7 +7,6 @@ import (
 	"github.com/fabric8-analytics/cli-tools/pkg/analyses/driver"
 	"github.com/fabric8-analytics/cli-tools/pkg/utils"
 	"github.com/rs/zerolog/log"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,7 +29,7 @@ func (m *Matcher) IgnoreVulnerabilities(manifestPath string) (map[string][]strin
 
 	log.Debug().Msgf("Extracting Packages and Vulnerabilities to Ignore.")
 	ignoreVulnerabilities := make(map[string][]string)
-	manifestFile, err := ioutil.ReadFile(manifestPath)
+	manifestFile, err := os.ReadFile(manifestPath)
 
 	if err != nil {
 		return ignoreVulnerabilities, err

--- a/pkg/analyses/pypi/pypi.go
+++ b/pkg/analyses/pypi/pypi.go
@@ -3,7 +3,6 @@ package pypi
 // This File contains Utility functions of Pypi Ecosystem
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -37,7 +36,7 @@ func checkExt(ext string) bool {
 func (m *Matcher) getPylistGenerator(pylistGenerator string) string {
 	log.Debug().Msgf("Executing: getPylistGenerator")
 	// Generating generate_pylist.py
-	err := ioutil.WriteFile(pylistGenerator, codeForPylist, 0644)
+	err := os.WriteFile(pylistGenerator, codeForPylist, 0644)
 	if err != nil {
 		log.Fatal().Msg("Error Generating generate_pylist.py")
 	}

--- a/pkg/analyses/stackanalyses/controller.go
+++ b/pkg/analyses/stackanalyses/controller.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -40,7 +39,7 @@ const (
 	RegisteredStatus = "REGISTERED"
 )
 
-//StackAnalyses is main controller function for analyse command. This function is responsible for all communications between cmd and custom packages.
+// StackAnalyses is main controller function for analyse command. This function is responsible for all communications between cmd and custom packages.
 func StackAnalyses(ctx context.Context, requestParams driver.RequestType, jsonOut bool, verboseOut bool) (bool, error) {
 	log.Debug().Msgf("Executing StackAnalyses.")
 	var hasVul bool
@@ -211,7 +210,7 @@ func (mc *Controller) validateGetResponse(apiResponse *http.Response) (*driver.G
 
 	//use TeeReader to duplicate the contents of the Response Body of type io.ReaderCloser since data is streamed from the response body.
 	r := io.TeeReader(apiResponse.Body, &buf)
-	responseBodyContents, _ := ioutil.ReadAll(r)
+	responseBodyContents, _ := io.ReadAll(r)
 	err := json.NewDecoder(&buf).Decode(&body)
 	if err != nil {
 		log.Error().Msg("analyse failed: Stack Analyses Get Request Failed. Please retry after sometime. If issue persists, Please raise at https://github.com/fabric8-analytics/cli-tools/issues.")

--- a/pkg/analyses/verbose/helper_test.go
+++ b/pkg/analyses/verbose/helper_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"github.com/fabric8-analytics/cli-tools/pkg/telemetry"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -15,13 +15,13 @@ import (
 func data() *driver.GetResponseType {
 	var body driver.GetResponseType
 	// json.NewDecoder(apiResponse.Body).Decode(&body)
-	plan, _ := ioutil.ReadFile("testdata/getresponse.json")
+	plan, _ := os.ReadFile("testdata/getresponse.json")
 	_ = json.Unmarshal(plan, &body)
 	return &body
 }
 func verboseData() *StackVerbose {
 	var body StackVerbose
-	plan, _ := ioutil.ReadFile("testdata/verbosedata.json")
+	plan, _ := os.ReadFile("testdata/verbosedata.json")
 	_ = json.Unmarshal(plan, &body)
 	return &body
 }

--- a/pkg/segment/segment_test.go
+++ b/pkg/segment/segment_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"github.com/rs/zerolog/log"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -24,7 +24,7 @@ func mockServer() (chan []byte, *httptest.Server) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
-		bin, err := ioutil.ReadAll(r.Body)
+		bin, err := io.ReadAll(r.Body)
 		if err != nil {
 			log.Error().Msgf(err.Error())
 			return
@@ -40,7 +40,7 @@ func TestClientUploadWithContext(t *testing.T) {
 	defer server.Close()
 	defer close(body)
 
-	dir, err := ioutil.TempDir("", "cfg")
+	dir, err := os.MkdirTemp("", "cfg")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -57,7 +57,7 @@ func TestClientUploadWithOutConsent(t *testing.T) {
 	defer server.Close()
 	defer close(body)
 
-	dir, err := ioutil.TempDir("", "cfg")
+	dir, err := os.MkdirTemp("", "cfg")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 


### PR DESCRIPTION
The ioutil package, as stated in the [docs](https://pkg.go.dev/io/ioutil) was deprecated in _GO 1.16_.

Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>
