### PR TITLE
ci: adjust the ci workflows to current stable versions

### DIFF
--- a/.github/workflows/ci-acctests.yml
+++ b/.github/workflows/ci-acctests.yml
@@ -1,5 +1,5 @@
 
-name: CI-Acceptance-Tests 
+name: CI-Acceptance-Tests
 
 on:
   pull_request:
@@ -16,57 +16,57 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.15
+        go-version: "1.20"
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: 'adopt'
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
-       python-version: '3.7'
-   
-    - uses: actions/setup-node@v2
+       python-version: '3.10'
+
+    - uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: '16'
     - name: Create comment
       if: github.event_name == 'repository_dispatch'  && github.event.action == 'acceptance-command'
       uses: peter-evans/create-or-update-comment@v1
       with:
         edit-mode: replace
-        comment-id: ${{ github.event.client_payload.github.payload.comment.id }} 
+        comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
         body: |
             **Edit:** :test_tube: [CI has Started acceptance Test]( https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})
-        reactions: eyes  
-    - name: build binary 
+        reactions: eyes
+    - name: build binary
       if: runner.os == 'Linux' || runner.os == 'macOS'
       run: go build -o acceptance-tests/crda
-    
+
     - name: build binary [Windows]
       if: runner.os == 'Windows'
       run: go build -o acceptance-tests/crda.exe
-    
+
     - name: Install dependencies
       run: go mod vendor
-    
+
     - name: Run Tests
-      working-directory: ./acceptance-tests 
+      working-directory: ./acceptance-tests
       env:
         THREE_SCALE_KEY: ${{ secrets.THREE_SCALE_KEY }}
         CRDA_KEY: ${{ secrets.CRDA_KEY }}
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       run: ./test.sh
       shell: bash
-    
+
     - name: Upload log as artifact
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Test-log-${{ runner.os }}
         path: ./acceptance-tests/logs.txt
@@ -80,13 +80,12 @@ jobs:
           :v: [E2E Run Successfull](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})
         reactions: hooray, heart
     - name: Create fail comment
-      if: failure() && github.event_name == 'repository_dispatch'  && github.event.action == 'acceptance-command' 
+      if: failure() && github.event_name == 'repository_dispatch'  && github.event.action == 'acceptance-command'
       uses: peter-evans/create-or-update-comment@v1
       with:
         edit-mode: replace
-        comment-id: ${{ github.event.client_payload.github.payload.comment.id }} 
+        comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
         body: |
           **Edit:** :facepalm: [Acceptance Tests Failed]( https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})
         reactions: confused
 
-      

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -7,64 +7,86 @@ on:
     branches: [ main ]
 
 jobs:
-  goreport:
-    name: Refresh-goreport
+  report:
+    name: Refresh GoReportCard
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: creekorful/goreportcard-action@v1.0
-  golangci-lint:
-    name: Linter
+    - name: Trigger report refresh
+      uses: creekorful/goreportcard-action@v1.0
+
+  lint:
+    name: Lint project
     runs-on: ubuntu-latest
+
     steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v4
-        with:
-          go-version: ^1.19
-      - uses: actions/checkout@v3
-      - name: Get dependencies
-        run: go mod download
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.52
-          working-directory: gomanifest
-          skip-build-cache: true
-          skip-pkg-cache: true
-  golint:
-    name: go Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v4
-        with:
-          go-version: ^1.19
-      - uses: actions/checkout@v3
-      - name: go vet
-        run: go vet ./...
-      - name: go run staticcheck
-        run: go run honnef.co/go/tools/cmd/staticcheck@latest ./...
-  build:
-    name: Build
-    runs-on: ubuntu-latest
+    - name: Checkout project
+      uses: actions/checkout@v3
+
+    - name: Setup Go 1.20
+      uses: actions/setup-go@v4
+      with:
+        go-version: "^1.20"
+
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: latest
+
+    - name: Run vet
+      run: go vet ./...
+
+    - name: Run staticcheck
+      run: go run honnef.co/go/tools/cmd/staticcheck@latest ./...
+
+  build_gomanifest:
+    name: Build GoManifest on ${{ matrix.os }}
+    needs: [lint]
     strategy:
-        matrix:
-            version:
-                - "1.18"
-                - "1.19"
-                - "1.20"
+      matrix:
+        os: [ "ubuntu-latest",  "macos-latest", "windows-latest" ]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: gomanifest
+
     steps:
-    - name: Set up Go 1.x
+    - name: Checkout project
+      uses: actions/checkout@v3
+
+    - name: Setup Go 1.15
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.15
+
+    - name: Build tool
+      run: go build -o ${{ runner.temp }}/gomanifest
+
+  build_module:
+    name: Build module
+    needs: [lint]
+    strategy:
+      matrix:
+        version: ["1.18",  "1.19", "1.20"]
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout project
+      uses: actions/checkout@v3
+
+    - name: Setup Go ${{ matrix.version }}
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.version }}
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
-    - name: Check go mod
+
+    - name: Verify go.mod
       run: |
-          go mod tidy
-          git diff --exit-code go.mod
+        go mod tidy
+        git diff --exit-code go.mod
+
     - name: Unit Test
       run:  go test `go list ./... | grep -v acceptance-tests` -gcflags=-l -v  -coverprofile=coverage.txt -covermode=atomic
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -39,8 +39,10 @@ jobs:
         with:
           go-version: ^1.19
       - uses: actions/checkout@v3
-      - name: lint
-        run: go run golang.org/x/lint/golint@latest ./...
+      - name: go vet
+        run: go vet ./...
+      - name: go run staticcheck
+        run: go run honnef.co/go/tools/cmd/staticcheck@latest ./...
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,16 +17,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: ^1.13
-      - uses: actions/checkout@v2
-      - name: Get dependencies 
+          go-version: ^1.19
+      - uses: actions/checkout@v3
+      - name: Get dependencies
         run: go mod download
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
-        with: 
-          version: v1.29
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.52
           working-directory: gomanifest
           skip-build-cache: true
           skip-pkg-cache: true
@@ -35,28 +35,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: ^1.13
-      - uses: actions/checkout@v2
+          go-version: ^1.19
+      - uses: actions/checkout@v3
       - name: lint
-        run: go get -u golang.org/x/lint/golint && golint ./...
+        run: go run golang.org/x/lint/golint@latest ./...
   build:
     name: Build
     runs-on: ubuntu-latest
     strategy:
         matrix:
             version:
-                - 1.13
-                - 1.14
-                - 1.15
+                - "1.18"
+                - "1.19"
+                - "1.20"
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.version }}
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Check go mod
       run: |
           go mod tidy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,15 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.16
+        go-version: "1.20"
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v2
+      uses: goreleaser/goreleaser-action@v4
       if: startsWith(github.ref, 'refs/tags/')
       with:
         version: latest

--- a/acceptance-tests/acceptance_tests_suite_test.go
+++ b/acceptance-tests/acceptance_tests_suite_test.go
@@ -16,10 +16,10 @@ func TestAcceptanceTests(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	SetDefaultEventuallyTimeout(2 * time.Minute)
-	helper.CreateDataDir()
+	_ = helper.CreateDataDir()
 	helper.CheckforSynkToken()
 })
 
 var _ = AfterSuite(func() {
-	helper.CleanupSuite()
+	_ = helper.CleanupSuite()
 })

--- a/acceptance-tests/staticcheck.conf
+++ b/acceptance-tests/staticcheck.conf
@@ -1,0 +1,3 @@
+# ST1000 = at least one file in a package should have a package comment
+# ST1001 = should not use dot imports
+checks = ["all", "-ST1000", "-ST1001"]

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -32,7 +32,7 @@ var authCmd = &cobra.Command{
 	Use:   "auth",
 	Short: "Links uuid with Snyk token.",
 	Long: fmt.Sprintf(`Command maps Snyk Token with UUID and Outputs 'crda_key' for further Authentication.
-	
+
 	To get "Snyk Token" Please click here: %s`, snykURL),
 	RunE: runAuth,
 }
@@ -99,7 +99,7 @@ func promptForToken() (string, error) {
 		}
 		return nil
 	}
-	fmt.Println(fmt.Sprintf("To get Snyk Token, Please click %s\n", snykURL))
+	fmt.Printf("To get Snyk Token, Please click %s\n", snykURL)
 	promptValues := &promptVars{
 		Name:        "Snyk Token",
 		Description: "[Press Enter to continue]",

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -13,47 +14,49 @@ var completionCmd = &cobra.Command{
 	Long: `To load completions:
 
 	Bash:
-	
+
 	$ source <(yourprogram completion bash)
-	
+
 	# To load completions for each session, execute once:
 	Linux:
 	  $ yourprogram completion bash > /etc/bash_completion.d/yourprogram
 	MacOS:
 	  $ yourprogram completion bash > /usr/local/etc/bash_completion.d/yourprogram
-	
+
 	Zsh:
-	
+
 	# If shell completion is not already enabled in your environment you will need
 	# to enable it.  You can execute the following once:
-	
+
 	$ echo "autoload -U compinit; compinit" >> ~/.zshrc
-	
+
 	# To load completions for each session, execute once:
 	$ yourprogram completion zsh > "${fpath[1]}/_yourprogram"
-	
+
 	# You will need to start a new shell for this setup to take effect.
-	
+
 	Fish:
-	
+
 	$ yourprogram completion fish | source
-	
+
 	# To load completions for each session, execute once:
 	$ yourprogram completion fish > ~/.config/fish/completions/yourprogram.fish
 	`,
 	DisableFlagsInUseLine: true,
 	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
 	Args:                  cobra.ExactValidArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		switch args[0] {
 		case "bash":
-			cmd.Root().GenBashCompletion(os.Stdout)
+			return cmd.Root().GenBashCompletion(os.Stdout)
 		case "zsh":
-			cmd.Root().GenZshCompletion(os.Stdout)
+			return cmd.Root().GenZshCompletion(os.Stdout)
 		case "fish":
-			cmd.Root().GenFishCompletion(os.Stdout, true)
+			return cmd.Root().GenFishCompletion(os.Stdout, true)
 		case "powershell":
-			cmd.Root().GenPowerShellCompletion(os.Stdout)
+			return cmd.Root().GenPowerShellCompletion(os.Stdout)
+		default:
+			return fmt.Errorf("unknown shell %s", args[0])
 		}
 	},
 }

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -31,7 +31,6 @@ var setCmd = &cobra.Command{
 			return
 		}
 		fmt.Println("successfully set configuration value")
-		return
 	},
 }
 

--- a/pkg/analyses/npm/matcher.go
+++ b/pkg/analyses/npm/matcher.go
@@ -56,7 +56,7 @@ func (m *Matcher) GeneratorDependencyTree(manifestFilePath string) string {
 		log.Debug().Msg("ERROR - Failed to Execute " + npmList.String() + "\n" + stderr.String())
 		log.Fatal().Err(err).Msgf("Missing Dependencies. Hint: Please install the required dependencies with \"npm install\" from the directory of the manifest file")
 	}
-	npmList.Wait()
+	_ = npmList.Wait()
 
 	log.Debug().Msgf("Success: buildDepsTree at %s", treePath)
 	return treePath

--- a/pkg/analyses/summary/helpers.go
+++ b/pkg/analyses/summary/helpers.go
@@ -90,16 +90,12 @@ func getSeverity(vulnerability []driver.VulnerabilitiesType, severity SeverityTy
 		switch vul.Severity {
 		case "critical":
 			severity.Critical++
-			break
 		case "high":
 			severity.High++
-			break
 		case "medium":
 			severity.Medium++
-			break
 		case "low":
 			severity.Low++
-			break
 		}
 	}
 	return severity

--- a/pkg/analyses/verbose/helper.go
+++ b/pkg/analyses/verbose/helper.go
@@ -117,16 +117,12 @@ func getSeverity(vulnerability []driver.VulnerabilitiesType, severity SeverityTy
 		switch vul.Severity {
 		case "critical":
 			severity.Critical = append(severity.Critical, vul)
-			break
 		case "high":
 			severity.High = append(severity.High, vul)
-			break
 		case "medium":
 			severity.Medium = append(severity.Medium, vul)
-			break
 		case "low":
 			severity.Low = append(severity.Low, vul)
-			break
 		}
 	}
 	return severity
@@ -151,7 +147,7 @@ func outputVerbosePlain(result *StackVerbose) {
 	)
 	fmt.Fprintln(os.Stdout, cusColor.Green("Fixable Issues:"))
 	outputVulDeps(result.Dependencies)
-	fmt.Fprint(os.Stdout, fmt.Sprintf(cusColor.White("\n\n Full Report: ")+"%s \n\n", result.ReportLink))
+	fmt.Fprintf(os.Stdout, cusColor.White("\n\n Full Report: ")+"%s \n\n", result.ReportLink)
 	fmt.Fprint(os.Stdout, "\n(Powered by Snyk)\n\n")
 }
 
@@ -169,15 +165,11 @@ func outputVulDeps(deps []DependenciesType) {
 			outputVulType(dep.PubliclyAvailableVulnerabilities, pkgName, pkgName)
 		}
 		if len(dep.VulnerableTransitives) > 0 {
-			fmt.Fprint(os.Stdout,
-				fmt.Sprintf(cusColor.Cyan("\n\t Issues in Transitives:\n")),
-			)
+			fmt.Fprint(os.Stdout, cusColor.Cyan("\n\t Issues in Transitives:\n"))
 
 			for _, trans := range dep.VulnerableTransitives {
 				transName := fmt.Sprintf("%s@%s", cusColor.White(trans.Name), cusColor.White(trans.Version))
-				fmt.Fprint(os.Stdout,
-					fmt.Sprintf("\t \u2712 %s->%s\n", pkgName, transName),
-				)
+				fmt.Fprintf(os.Stdout,"\t \u2712 %s->%s\n", pkgName, transName)
 				trans.PubliclyAvailableVulnerabilities = append(trans.PubliclyAvailableVulnerabilities, trans.VulnerabilitiesUniqueToSynk...)
 				outputVulType(trans.PubliclyAvailableVulnerabilities, transName, pkgName)
 			}
@@ -211,19 +203,15 @@ func getSeverityIntesity(severity string) (color.Attribute, string) {
 	case "critical":
 		myColor = color.FgHiRed
 		vulText = "Critical Severity"
-		break
 	case "high":
 		myColor = color.FgHiMagenta
 		vulText = "High Severity"
-		break
 	case "medium":
 		myColor = color.FgHiYellow
 		vulText = "Medium Severity"
-		break
 	case "low":
 		myColor = color.FgHiBlue
 		vulText = "Low Severity"
-		break
 	}
 	return myColor, vulText
 

--- a/pkg/analyses/verbose/helper_test.go
+++ b/pkg/analyses/verbose/helper_test.go
@@ -16,13 +16,13 @@ func data() *driver.GetResponseType {
 	var body driver.GetResponseType
 	// json.NewDecoder(apiResponse.Body).Decode(&body)
 	plan, _ := ioutil.ReadFile("testdata/getresponse.json")
-	json.Unmarshal(plan, &body)
+	_ = json.Unmarshal(plan, &body)
 	return &body
 }
 func verboseData() *StackVerbose {
 	var body StackVerbose
 	plan, _ := ioutil.ReadFile("testdata/verbosedata.json")
-	json.Unmarshal(plan, &body)
+	_ = json.Unmarshal(plan, &body)
 	return &body
 }
 

--- a/pkg/config/viper_config.go
+++ b/pkg/config/viper_config.go
@@ -19,10 +19,10 @@ var ActiveConfigValues = &viperConfigs{}
 func ViperUnMarshal() *viperConfigs {
 	viper.AutomaticEnv()
 	// Have to bind individual variables: https://github.com/spf13/viper/issues/188
-	viper.BindEnv("CONSENT_TELEMETRY")
-	viper.BindEnv("CRDA_AUTH_TOKEN")
-	viper.BindEnv("CRDA_HOST")
-	viper.BindEnv("CRDA_KEY")
+	_ = viper.BindEnv("CONSENT_TELEMETRY")
+	_ = viper.BindEnv("CRDA_AUTH_TOKEN")
+	_ = viper.BindEnv("CRDA_HOST")
+	_ = viper.BindEnv("CRDA_KEY")
 	err := viper.Unmarshal(&ActiveConfigValues)
 	if err != nil {
 		log.Fatal().Msgf("unable to decode into struct, %v", err)

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -15,7 +15,7 @@ func TestSetError(t *testing.T) {
 
 	currentUser, err := user.Current()
 	assert.NoError(t, err)
-	configHome, err := homedir.Dir()
+	configHome, _ := homedir.Dir()
 	err = fmt.Errorf("cannot access storage file '%s/.crc/machines/crc/crc.qcow2' (as uid:64055, gid:129): Permission denied')", configHome)
 	assert.NotEqual(t, err.Error(), SetError(err))
 	assert.NotContains(t, SetError(err), configHome)


### PR DESCRIPTION
- ci: update release workflow runner, actions, and go versions
- ci: update acceptance workflow actions, python, node, and go versions
- ci: update build workflow actions, linting, and go versions
- chore: fixed lint errors reporeted golangci-lint
- ci: golint is deprecated and archived, vet and staticcheck are the recomended replacement
